### PR TITLE
Fix random word display logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
 let word = "Bear"
 function stringToArray(str) {
-    let arr = []
-    for (let i = 0; i < str.length; i++){
-        arr.push(str[i])
-    }
-    return arr
+    return str.split("")
 }
 function variar(str){
     let arr = stringToArray(str)
@@ -13,7 +9,7 @@ function variar(str){
         [arr[i], arr[j]] = [arr[j], arr[i]]
     }
 
-    return arr
+    return arr.join("")
 }
 
 class Bear extends React.Component {


### PR DESCRIPTION
## Summary
- fix stringToArray helper
- return shuffled word as a string

## Testing
- `node - <<'EOF'
function stringToArray(str){return str.split("")}
function variar(str){let arr=stringToArray(str); for(let i=arr.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]]}; return arr.join("")}
console.log(variar('Bear'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684b2b69a5e483258fa3be641d3c792b