### PR TITLE
Add color name tests

### DIFF
--- a/node_modules/color-name/test.js
+++ b/node_modules/color-name/test.js
@@ -5,3 +5,5 @@ var assert = require('assert');
 
 assert.deepEqual(names.red, [255,0,0]);
 assert.deepEqual(names.aliceblue, [240,248,255]);
+assert.deepEqual(names.blue, [0,0,255]);
+assert.deepEqual(names.black, [0,0,0]);


### PR DESCRIPTION
## Summary
- enhance color-name's tests with more RGB checks

## Testing
- `node node_modules/color-name/test.js`

------
https://chatgpt.com/codex/tasks/task_e_684b2c75f1088325825c55778848e07e